### PR TITLE
Added base_href variable

### DIFF
--- a/scripts/boilerplate/_data/project.yml
+++ b/scripts/boilerplate/_data/project.yml
@@ -2,3 +2,4 @@ title:
 tagline:
 description:
 google_analytics_tracking_id:
+base_href:

--- a/scripts/boilerplate/_layouts/default.html
+++ b/scripts/boilerplate/_layouts/default.html
@@ -23,6 +23,7 @@
         <link rel="apple-touch-icon-precomposed" href="http://theme.thephpleague.com/img/apple-touch-icon-precomposed.png">
     {% endif %}
     <link rel="stylesheet" href="http://theme.thephpleague.com/css/all.css">
+    <base href="{{ site.data.project.base_href }}">
 </head>
 <body>
 


### PR DESCRIPTION
Our pages can be accessed via http://thephpleague.com/PROJECT_NAME/, as well as whatever we put in the CNAME file, 

When that happens, all of the navigation links break. To fix this, I've added a base_href variable that can be defined in projects.yml
