### PR TITLE
Add horizontal padding to table cells

### DIFF
--- a/_sass/base/template.scss
+++ b/_sass/base/template.scss
@@ -657,7 +657,7 @@ main
 
             td,
             th {
-                padding: 2px 0;
+                padding: 2px 10px;
                 text-align: left;
                 border-bottom: solid 1px #ccc;
             }


### PR DESCRIPTION
Can we add a bit of horizontal padding back to the table cells? I'm trying to create a table in docs now but it's really scrunched looking.

http://imgur.com/Zh1FLj8

Alternately, we can add the padding just to the right side if we want to keep everything flush to the left.
